### PR TITLE
fix new workers hanging forever

### DIFF
--- a/src/runtime/threadpool/builder.rs
+++ b/src/runtime/threadpool/builder.rs
@@ -272,6 +272,9 @@ impl Builder {
 
         // Set the tokio 0.1 executor to be used by the worker threads.
         *compat_sender = Some(runtime.spawner());
+        // Releasing the write lock allows the workers to unblock and access the
+        // sender.
+        drop(compat_sender);
 
         Ok(runtime)
     }

--- a/src/runtime/threadpool/tests.rs
+++ b/src/runtime/threadpool/tests.rs
@@ -119,12 +119,9 @@ fn tokio_02_blocking_shutdown() {
     let ran = Arc::new(AtomicBool::new(false));
     let ran2 = ran.clone();
     super::run_std(async move {
-        println!("in future, before blocking");
         tokio_02::executor::thread_pool::blocking(move || {
-            println!("in blocking");
             ran.store(true, Ordering::SeqCst);
         });
-        println!("blocking done");
     });
     assert!(ran2.load(Ordering::SeqCst));
 }

--- a/src/runtime/threadpool/tests.rs
+++ b/src/runtime/threadpool/tests.rs
@@ -113,3 +113,18 @@ fn block_on_std_01_spawn() {
     // is that we're able to spawn it successfully.
     rt.block_on_std(async { tokio_01::spawn(futures_01::future::lazy(|| Ok(()))) });
 }
+
+#[test]
+fn tokio_02_blocking_shutdown() {
+    let ran = Arc::new(AtomicBool::new(false));
+    let ran2 = ran.clone();
+    super::run_std(async move {
+        println!("in future, before blocking");
+        tokio_02::executor::thread_pool::blocking(move || {
+            println!("in blocking");
+            ran.store(true, Ordering::SeqCst);
+        });
+        println!("blocking done");
+    });
+    assert!(ran2.load(Ordering::SeqCst));
+}


### PR DESCRIPTION
## Motivation

Currently, an `Arc<RwLock>` is used to store the compat runtime's sender
so that it can be set as the default tokio 0.1 executor for the
runtime's worker threads. Since the runtime must first be created before
the sender is available, the current `around_worker` closure uses a
barrier to wait for the sender to be available in the RwLock before it
continues. This works fine when all the workers are created at once,
since the barrier will block the max number of worker threads on the
threadpool, plus one for the thread creating the runtime.

However, when new worker threads are added to the runtime, they will block
indefinitely. When `tokio` 0.2's in-place blocking API is used, a new
worker is created to replace the thread that transitions to blocking.
These new threads are not created all at once, so they block on the
barrier and are not allowed to continue. If the runtime then shuts down
without creating `max_threads` + 1 additional workers, any new workers
blocking on the barrier will hang forever, preventing shutdown. In a
real world application, this also means that continued uses of
`blocking` would eventually starve the threadpool of workers.

## Solution

This branch fixes the issue by removing the barrier, which was not
actually necessary in the first place. Since the compat sender is only
ever set once, we can simply acquire the write lock in the thread
constructing the runtime before cloning the `Arc` into the
`around_worker` closure, and only drop that write lock when the sender
is set. This will prevent the workers from accessing it before it is
ready, but once the runtime has been created, any subsequent workers
will not block.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>