### PR TITLE
Add `futures-io` compatibility layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,9 @@ keywords = ["io", "async", "non-blocking", "futures"]
 
 
 [features]
-default = ["rt-full", "sink"]
+default = ["rt-full", "sink", "futures-io"]
+io = ["tokio-02/io", "pin-project"]
+futures-io = ["io", "futures-io-preview"]
 # enables the compat runtimes.
 rt-current-thread = [
     "tokio-timer-02",
@@ -48,6 +50,10 @@ futures-01 = { package = "futures", version = "0.1" }
 futures-03-core = { package = "futures-core-preview", version = "0.3.0-alpha.19" }
 futures-util = { package = "futures-util-preview", version = "0.3.0-alpha.19", default-features = false, features = ["compat"] }
 tokio-02 = { package = "tokio", git = "https://github.com/tokio-rs/tokio", rev ="e699d4653", default_features = false }
+
+# io
+futures-io-preview = { version = "0.3.0-alpha.19", optional = true }
+pin-project = { version = "0.4", optional = true }
 
 # runtime-only
 tokio-timer-02 = { package = "tokio-timer", version = "0.2", optional = true}

--- a/src/io/futures_io.rs
+++ b/src/io/futures_io.rs
@@ -1,0 +1,183 @@
+//! Compatibility between the `tokio::io` and `futures-io` versions of the
+//! `AsyncRead` and `AsyncWrite` traits.
+use pin_project::pin_project;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// A compatibility layer that allows conversion between the
+/// `tokio::io` and `futures-io` `AsyncRead` and `AsyncWrite` traits.
+#[pin_project]
+#[derive(Copy, Clone, Debug)]
+pub struct Compat<T> {
+    #[pin]
+    inner: T,
+}
+
+/// Extension trait that allows converting a type implementing
+/// `futures_io::AsyncRead` to implement `tokio::io::AsyncRead`.
+pub trait FuturesAsyncReadCompatExt: futures_io::AsyncRead {
+    /// Wraps `self` with a compatibility layer that implements
+    /// `tokio_io::AsyncWrite`.
+    fn compat(self) -> Compat<Self>
+    where
+        Self: Sized,
+    {
+        Compat::new(self)
+    }
+}
+
+impl<T: futures_io::AsyncRead> FuturesAsyncReadCompatExt for T {}
+
+/// Extension trait that allows converting a type implementing
+/// `futures_io::AsyncWrite` to implement `tokio::io::AsyncWrite`.
+pub trait FuturesAsyncWriteCompatExt: futures_io::AsyncWrite {
+    /// Wraps `self` with a compatibility layer that implements
+    /// `tokio::io::AsyncWrite`.
+    fn compat_write(self) -> Compat<Self>
+    where
+        Self: Sized,
+    {
+        Compat::new(self)
+    }
+}
+
+impl<T: futures_io::AsyncWrite> FuturesAsyncWriteCompatExt for T {}
+
+/// Extension trait that allows converting a type implementing
+/// `tokio::io::AsyncRead` to implement `futures_io::AsyncRead`.
+pub trait Tokio02AsyncReadCompatExt: tokio_02::io::AsyncRead {
+    /// Wraps `self` with a compatibility layer that implements
+    /// `futures_io::AsyncRead`.
+    fn compat(self) -> Compat<Self>
+    where
+        Self: Sized,
+    {
+        Compat::new(self)
+    }
+}
+
+impl<T: tokio_02::io::AsyncRead> Tokio02AsyncReadCompatExt for T {}
+
+/// Extension trait that allows converting a type implementing
+/// `tokio::io::AsyncWrite` to implement `futures_io::AsyncWrite`.
+pub trait Tokio02AsyncWriteCompatExt: tokio_02::io::AsyncWrite {
+    /// Wraps `self` with a compatibility layer that implements
+    /// `futures_io::AsyncWrite`.
+    fn compat_write(self) -> Compat<Self>
+    where
+        Self: Sized,
+    {
+        Compat::new(self)
+    }
+}
+
+impl<T: tokio_02::io::AsyncWrite> Tokio02AsyncWriteCompatExt for T {}
+
+// === impl Compat ===
+
+impl<T> Compat<T> {
+    fn new(inner: T) -> Self {
+        Self { inner }
+    }
+}
+
+impl<T> tokio_02::io::AsyncRead for Compat<T>
+where
+    T: futures_io::AsyncRead,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        futures_io::AsyncRead::poll_read(self.project().inner, cx, buf)
+    }
+}
+
+impl<T> futures_io::AsyncRead for Compat<T>
+where
+    T: tokio_02::io::AsyncRead,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        tokio_02::io::AsyncRead::poll_read(self.project().inner, cx, buf)
+    }
+}
+
+impl<T> tokio_02::io::AsyncBufRead for Compat<T>
+where
+    T: futures_io::AsyncBufRead,
+{
+    fn poll_fill_buf<'a>(
+        self: Pin<&'a mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<&'a [u8]>> {
+        futures_io::AsyncBufRead::poll_fill_buf(self.project().inner, cx)
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        futures_io::AsyncBufRead::consume(self.project().inner, amt)
+    }
+}
+
+impl<T> futures_io::AsyncBufRead for Compat<T>
+where
+    T: tokio_02::io::AsyncBufRead,
+{
+    fn poll_fill_buf<'a>(
+        self: Pin<&'a mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<&'a [u8]>> {
+        tokio_02::io::AsyncBufRead::poll_fill_buf(self.project().inner, cx)
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        tokio_02::io::AsyncBufRead::consume(self.project().inner, amt)
+    }
+}
+
+impl<T> tokio_02::io::AsyncWrite for Compat<T>
+where
+    T: futures_io::AsyncWrite,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        futures_io::AsyncWrite::poll_write(self.project().inner, cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        futures_io::AsyncWrite::poll_flush(self.project().inner, cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        futures_io::AsyncWrite::poll_close(self.project().inner, cx)
+    }
+}
+
+impl<T> futures_io::AsyncWrite for Compat<T>
+where
+    T: tokio_02::io::AsyncWrite,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        tokio_02::io::AsyncWrite::poll_write(self.project().inner, cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        tokio_02::io::AsyncWrite::poll_flush(self.project().inner, cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        tokio_02::io::AsyncWrite::poll_shutdown(self.project().inner, cx)
+    }
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,0 +1,4 @@
+//! Compatibility between the `tokio::io` `AsyncRead` and `AsyncWrite` traits,
+//! and other versions of those traits.
+#[cfg(feature = "futures-io")]
+pub mod futures_io;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,13 @@
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
+
 #[cfg(any(feature = "rt-current-thread", feature = "rt-full"))]
 pub mod runtime;
 #[cfg(feature = "rt-full")]
 pub use self::runtime::{run, run_std};
+
+#[cfg(feature = "io")]
+pub mod io;
+
 pub mod prelude;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,3 +2,9 @@
 #[cfg(feature = "sink")]
 pub use futures_util::compat::Sink01CompatExt as _;
 pub use futures_util::compat::{Future01CompatExt as _, Stream01CompatExt as _};
+
+#[cfg(feature = "futures_io")]
+pub use self::futures_io::{
+    FuturesIoAsyncReadCompatExt as _, FuturesIoAsyncWriteCompatExt as _,
+    Tokio02AsyncReadCompatExt as _, Tokio02AsyncWriteCompatExt as _,
+};


### PR DESCRIPTION
This PR adds a compatibility layer with conversions between the 
`tokio::io` and `futures-io` versions of the `AsyncRead` and 
`AsyncWrite` traits.

A compatibility layer between `tokio` 0.2 and `tokio` 0.1's async
IO traits will be added in a subsequent PR. The `futures-io` and 
`tokio` 0.1 compatibility modules will be available in separate feature
flags.

This is based on code originally written by @Nemo157 as part of the
`futures-tokio-compat` crate, and is contributed on behalf of the
original author:
https://github.com/Nemo157/futures-tokio-compat/issues/2#issuecomment-544118866

Co-authored-by: Wim Looman <wim@nemo157.com>
Signed-off-by: Eliza Weisman <eliza@buoyant.io>