### PR TITLE
runtime: fix hang when calling `block_on` multiple times

### DIFF
--- a/src/runtime/idle.rs
+++ b/src/runtime/idle.rs
@@ -42,7 +42,7 @@ impl Track {
     /// Run a task, decrementing the spawn count when it completes.
     ///
     /// If the spawned count is now 0, this sends a notification on the idle channel.
-    pub(super) async fn with<T>(mut self, f: impl Future<Output = T>) -> T {
+    pub(super) async fn with<T>(self, f: impl Future<Output = T>) -> T {
         let result = f.await;
         let spawned = self.0.spawned.fetch_sub(1, Ordering::Release);
         if spawned == 1 {

--- a/src/runtime/idle.rs
+++ b/src/runtime/idle.rs
@@ -4,7 +4,7 @@ use std::sync::{
     Arc,
 };
 use tokio_02::sync::mpsc;
-pub(super) type Rx = mpsc::Receiver<()>;
+pub(super) type Rx = mpsc::UnboundedReceiver<()>;
 /// Tracks the number of tasks spawned on a runtime.
 ///
 /// This is required to implement `shutdown_on_idle` and `tokio::run` APIs that
@@ -12,7 +12,7 @@ pub(super) type Rx = mpsc::Receiver<()>;
 /// `shutdown_on_idle` API.
 #[derive(Clone, Debug)]
 pub(super) struct Idle {
-    tx: mpsc::Sender<()>,
+    tx: mpsc::UnboundedSender<()>,
     spawned: Arc<AtomicUsize>,
 }
 
@@ -23,7 +23,7 @@ pub(super) struct Track(Idle);
 
 impl Idle {
     pub(super) fn new() -> (Self, Rx) {
-        let (tx, rx) = mpsc::channel(1);
+        let (tx, rx) = mpsc::unbounded_channel();
         let this = Self {
             tx,
             spawned: Arc::new(AtomicUsize::new(0)),
@@ -47,7 +47,7 @@ impl Track {
         let spawned = self.0.spawned.fetch_sub(1, Ordering::Release);
         if spawned == 1 {
             fence(Ordering::Acquire);
-            let _ = self.0.tx.send(()).await;
+            let _ = self.0.tx.send(());
         }
         result
     }

--- a/tests/rt_current_thread.rs
+++ b/tests/rt_current_thread.rs
@@ -125,8 +125,26 @@ fn tokio_02_spawn_blocking_works() {
         tokio_02::task::spawn_blocking(move || {
             println!("in blocking");
             ran.store(true, Ordering::SeqCst);
-        }).await.expect("blocking task panicked!");
+        })
+        .await
+        .expect("blocking task panicked!");
         println!("blocking done");
     });
     assert!(ran2.load(Ordering::SeqCst));
+}
+
+#[test]
+fn block_on_twice() {
+    // Repro for tokio-rs/tokio-compat#10.
+    let mut rt = current_thread::Runtime::new().unwrap();
+    rt.block_on_std(async {
+        tokio_02::spawn(async {}).await;
+        println!("spawn 1 done")
+    });
+    println!("block_on 1 done");
+    rt.block_on_std(async {
+        tokio_02::spawn(async {}).await;
+        println!("spawn 2 done");
+    });
+    println!("done");
 }

--- a/tests/rt_current_thread.rs
+++ b/tests/rt_current_thread.rs
@@ -138,12 +138,12 @@ fn block_on_twice() {
     // Repro for tokio-rs/tokio-compat#10.
     let mut rt = current_thread::Runtime::new().unwrap();
     rt.block_on_std(async {
-        tokio_02::spawn(async {}).await;
+        tokio_02::spawn(async {}).await.unwrap();
         println!("spawn 1 done")
     });
     println!("block_on 1 done");
     rt.block_on_std(async {
-        tokio_02::spawn(async {}).await;
+        tokio_02::spawn(async {}).await.unwrap();
         println!("spawn 2 done");
     });
     println!("done");

--- a/tests/rt_threadpool.rs
+++ b/tests/rt_threadpool.rs
@@ -124,7 +124,9 @@ fn tokio_02_spawn_blocking_works() {
         tokio_02::task::spawn_blocking(move || {
             println!("in blocking");
             ran.store(true, Ordering::SeqCst);
-        }).await.expect("blocking task panicked!");
+        })
+        .await
+        .expect("blocking task panicked!");
         println!("blocking done");
     });
     assert!(ran2.load(Ordering::SeqCst));
@@ -141,8 +143,26 @@ fn tokio_02_block_in_place_works() {
                 println!("in blocking");
                 ran.store(true, Ordering::SeqCst);
             })
-        }).await.expect("blocking task panicked!");
+        })
+        .await
+        .expect("blocking task panicked!");
         println!("blocking done");
     });
     assert!(ran2.load(Ordering::SeqCst));
+}
+
+#[test]
+fn block_on_twice() {
+    // Repro for tokio-rs/tokio-compat#10.
+    let mut rt = runtime::Runtime::new().unwrap();
+    rt.block_on_std(async {
+        tokio_02::spawn(async {}).await;
+        println!("spawn 1 done")
+    });
+    println!("block_on 1 done");
+    rt.block_on_std(async {
+        tokio_02::spawn(async {}).await;
+        println!("spawn 2 done");
+    });
+    println!("done");
 }

--- a/tests/rt_threadpool.rs
+++ b/tests/rt_threadpool.rs
@@ -156,12 +156,12 @@ fn block_on_twice() {
     // Repro for tokio-rs/tokio-compat#10.
     let mut rt = runtime::Runtime::new().unwrap();
     rt.block_on_std(async {
-        tokio_02::spawn(async {}).await;
+        tokio_02::spawn(async {}).await.unwrap();
         println!("spawn 1 done")
     });
     println!("block_on 1 done");
     rt.block_on_std(async {
-        tokio_02::spawn(async {}).await;
+        tokio_02::spawn(async {}).await.unwrap();
         println!("spawn 2 done");
     });
     println!("done");


### PR DESCRIPTION
Currently, if `Runtime::block_on` or `block_on_std` is called multiple
times on the same runtime, and no background futures are running when
the `block_on` future finishes, the second call will never return. This
is because the channel used for detecting idleness is currently a
bounded channel of size 1, and the idle message that's sent when the first
`block_on` ends is never cleared. Therefore, the send when the second
`block_on` ends hangs for ever.

This branch fixes this issue by making the idle channel unbounded.

Fixes #10

Signed-off-by: Eliza Weisman <eliza@buoyant.io>