### PR TITLE
runtime: fix `shutdown_on_idle` completing early

### DIFF
--- a/src/runtime/current_thread/runtime.rs
+++ b/src/runtime/current_thread/runtime.rs
@@ -370,7 +370,7 @@ impl Runtime {
         let _timer = timer_02::timer::set_default(compat.timer());
 
         executor_01::with_default(&mut spawner, &mut enter, |_enter| {
-            Self::with_idle(idle, move || local.block_on(inner, idle_rx.recv()))
+            Self::with_idle(idle, move || local.block_on(inner, idle_rx.idle()))
         });
         Ok(())
     }

--- a/src/runtime/idle.rs
+++ b/src/runtime/idle.rs
@@ -49,20 +49,6 @@ impl Idle {
 }
 
 impl Rx {
-    // pub(super) async fn drain(&mut self) {
-    //     struct Drain<'a>(&'a mut mpsc::UnboundedReceiver<()>);
-    //     impl<'a> Future for Drain<'a> {
-    //         type Output = ();
-
-    //         fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-    //             let rx = &mut self.as_mut().0;
-    //             while let Poll::Ready(Some(_)) = rx.poll_recv(cx) {}
-    //             Poll::Ready(())
-    //         }
-    //     }
-    //     Drain(&mut self.0).await
-    // }
-
     pub(super) async fn idle(&mut self) {
         while self.spawned.load(Ordering::Acquire) != 0 {
             // Wait to be woken up again.

--- a/src/runtime/threadpool/mod.rs
+++ b/src/runtime/threadpool/mod.rs
@@ -493,7 +493,7 @@ impl Runtime {
         let _timer = timer_02::timer::set_default(compat_bg.timer());
         let _reactor = reactor_01::set_default(compat_bg.reactor());
         let _executor = executor_01::set_default(spawner);
-        runtime.block_on(self.idle_rx.recv());
+        runtime.block_on(self.idle_rx.idle());
         let f = futures_01::future::lazy(move || Ok(()));
 
         Shutdown { inner: Box::new(f) }


### PR DESCRIPTION
Depends on #11


## Motivation

Currently, `Runtime::shutdown_on_idle` and
`current_thread::Runtime::run` can finish immediately if a runtime has
ever run a future that counts towards idleness previously. This means
that any spawned futures are not run.

## Solution

This branch fixes the problem by checking the number of spawned futures
when an idle notification is received. If it's non-zero, then the idle
notification is stale and came from a previous `block_on` call. In that
case, we skip it and wait for the next one.

I've also added tests for this issue (and confirmed they fail against
master).

Signed-off-by: Eliza Weisman <eliza@buoyant.io>