### PR TITLE
prepare to release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# 0.1.1 (December 18, 2019)
+
+### Fixed
+
+- Hang when calling `block_on` twice on the same `Runtime` (#11)
+- `Runtime::shutdown_on_idle` and `current_thread::Runtime::run` completing
+  early when a future has completed previously on that runtime (#12)
+
+# 0.1.0 (December 17, 2019)
+
+- Initial release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio-compat"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio-compat/0.1.0/tokio-compat/"
+documentation = "https://docs.rs/tokio-compat/0.1.1/tokio-compat/"
 repository = "https://github.com/tokio-rs/tokio-compat"
 homepage = "https://tokio.rs"
 description = """

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Compatibility layers between `tokio` 0.2 and legacy versions.
 
 [crates-badge]: https://img.shields.io/crates/v/tokio-compat.svg
 [crates-url]: https://crates.io/crates/tokio-compat
-[docs-url]: https://docs.rs/tokio-compat/0.1.0/tokio-compat
+[docs-url]: https://docs.rs/tokio-compat/0.1.1/tokio-compat
 [docs-badge]: https://docs.rs/tokio-compat/badge.svg
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 //! - `rt-current-thread`: enables the `current_thread` compatibilty runtime
 //! - `rt-full`: enables the `current_thread` and threadpool compatibility
 //!   runtimes (enabled by default)
-#![doc(html_root_url = "https://docs.rs/tokio-compat/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/tokio-compat/0.1.1")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
# 0.1.1 (December 18, 2019)

### Fixed

- Hang when calling `block_on` twice on the same `Runtime` (#11)
- `Runtime::shutdown_on_idle` and `current_thread::Runtime::run` completing
  early when a future has completed previously on that runtime (#12)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>