### PR TITLE
Use stable futures crates instead of preview

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ sink = ["futures-util/sink"]
 
 [dependencies]
 futures-01 = { package = "futures", version = "0.1" }
-futures-03-core = { package = "futures-core-preview", version = "0.3.0-alpha.19" }
-futures-util = { package = "futures-util-preview", version = "0.3.0-alpha.19", default-features = false, features = ["compat"] }
+futures-03-core = { package = "futures-core", version = "0.3.1" }
+futures-util = { version = "0.3.1", default-features = false, features = ["compat"] }
 tokio-02 = { package = "tokio", version = "0.2.4", default-features = false }
 pin-project-lite = { version = "0.1", optional = true }
 


### PR DESCRIPTION
This might warrant another release so the crate can be used with stable futures.