### PR TITLE
prepare to release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.2 (December 18, 2019)
+
+### Fixed
+
+- Dependencies on `futures-core-preview` and `futures-util-preview` updated to
+  release `futures` 0.3 versions (#14)
+
 # 0.1.1 (December 18, 2019)
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ pin-project-lite = { version = "0.1", optional = true }
 
 # runtime-only
 tokio-timer-02 = { package = "tokio-timer", version = "0.2.12", optional = true }
-tokio-reactor-01 = { package = "tokio-reactor", version = "0.1.21", optional = true  }
+tokio-reactor-01 = { package = "tokio-reactor", version = "0.1.11", optional = true  }
 tokio-executor-01 = { package = "tokio-executor", version = "0.1.9", optional = true }
 tokio-current-thread-01 = { package = "tokio-current-thread", version = "0.1", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio-compat"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.1"
+version = "0.1.2"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio-compat/0.1.1/tokio-compat/"
+documentation = "https://docs.rs/tokio-compat/0.1.2/tokio-compat/"
 repository = "https://github.com/tokio-rs/tokio-compat"
 homepage = "https://tokio.rs"
 description = """
@@ -57,7 +57,7 @@ pin-project-lite = { version = "0.1", optional = true }
 
 # runtime-only
 tokio-timer-02 = { package = "tokio-timer", version = "0.2.12", optional = true }
-tokio-reactor-01 = { package = "tokio-reactor", version = "0.1.11", optional = true  }
+tokio-reactor-01 = { package = "tokio-reactor", version = "0.1.21", optional = true  }
 tokio-executor-01 = { package = "tokio-executor", version = "0.1.9", optional = true }
 tokio-current-thread-01 = { package = "tokio-current-thread", version = "0.1", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Compatibility layers between `tokio` 0.2 and legacy versions.
 
 [crates-badge]: https://img.shields.io/crates/v/tokio-compat.svg
 [crates-url]: https://crates.io/crates/tokio-compat
-[docs-url]: https://docs.rs/tokio-compat/0.1.1/tokio-compat
+[docs-url]: https://docs.rs/tokio-compat/0.1.2/tokio-compat
 [docs-badge]: https://docs.rs/tokio-compat/badge.svg
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 //! - `rt-current-thread`: enables the `current_thread` compatibilty runtime
 //! - `rt-full`: enables the `current_thread` and threadpool compatibility
 //!   runtimes (enabled by default)
-#![doc(html_root_url = "https://docs.rs/tokio-compat/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/tokio-compat/0.1.2")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
# 0.1.2 (December 18, 2019)

### Fixed

- Dependencies on `futures-core-preview` and `futures-util-preview` updated to
  release `futures` 0.3 versions (#14)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>