### PR TITLE
WIP on tokio-compat macros.

### DIFF
--- a/tokio-compat-macros/Cargo.toml
+++ b/tokio-compat-macros/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "tokio-compat-macros"
+version = "0.1.2"
+edition = "2018"
+authors = ["Tokio Contributors <team@tokio.rs>"]
+license = "MIT"
+readme = "README.md"
+documentation = "https://docs.rs/tokio-compat/0.1.2/tokio-compat/"
+repository = "https://github.com/tokio-rs/tokio-compat"
+homepage = "https://tokio.rs"
+description = """
+Compatibility between `tokio` 0.2 and legacy versions.
+"""
+categories = ["asynchronous", "network-programming"]
+keywords = ["io", "async", "non-blocking", "futures", "tokio"]
+
+[lib]
+proc-macro = true
+
+[features]
+
+[dependencies]
+quote = "1"
+syn = { version = "1.0.3", features = ["full"] }

--- a/tokio-compat-macros/src/lib.rs
+++ b/tokio-compat-macros/src/lib.rs
@@ -1,0 +1,153 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+
+enum Runtime {
+    Basic,
+    Threaded,
+    Auto,
+}
+
+#[proc_macro_attribute]
+#[cfg(not(test))] // Work around for rust-lang/rust#62127
+pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(item as syn::ItemFn);
+    let args = syn::parse_macro_input!(args as syn::AttributeArgs);
+
+    let ret = &input.sig.output;
+    let name = &input.sig.ident;
+    let inputs = &input.sig.inputs;
+    let body = &input.block;
+    let attrs = &input.attrs;
+    let vis = input.vis;
+
+    if input.sig.asyncness.is_none() {
+        let msg = "the async keyword is missing from the function declaration";
+        return syn::Error::new_spanned(input.sig.fn_token, msg)
+            .to_compile_error()
+            .into();
+    } else if name == "main" && !inputs.is_empty() {
+        let msg = "the main function cannot accept arguments";
+        return syn::Error::new_spanned(&input.sig.inputs, msg)
+            .to_compile_error()
+            .into();
+    }
+
+    let mut runtime = Runtime::Auto;
+
+    for arg in args {
+        if let syn::NestedMeta::Meta(syn::Meta::Path(path)) = arg {
+            let ident = path.get_ident();
+            if ident.is_none() {
+                let msg = "Must have specified ident";
+                return syn::Error::new_spanned(path, msg)
+                    .to_compile_error()
+                    .into();
+            }
+            match ident.unwrap().to_string().to_lowercase().as_str() {
+                "threaded_scheduler" => runtime = Runtime::Threaded,
+                "basic_scheduler" => runtime = Runtime::Basic,
+                name => {
+                    let msg = format!("Unknown attribute {} is specified; expected `basic_scheduler` or `threaded_scheduler`", name);
+                    return syn::Error::new_spanned(path, msg)
+                        .to_compile_error()
+                        .into();
+                }
+            }
+        }
+    }
+
+    let result = match runtime {
+        Runtime::Threaded | Runtime::Auto => quote! {
+            #(#attrs)*
+            #vis fn #name(#inputs) #ret {
+                tokio_compat::runtime::Runtime::new().unwrap().block_on_std(async { #body })
+            }
+        },
+        Runtime::Basic => quote! {
+            #(#attrs)*
+            #vis fn #name(#inputs) #ret {
+                tokio_compat::runtime::current_thread::Runtime::new().unwrap().block_on_std(async { #body })
+            }
+        },
+    };
+
+    result.into()
+}
+
+#[proc_macro_attribute]
+pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(item as syn::ItemFn);
+    let args = syn::parse_macro_input!(args as syn::AttributeArgs);
+
+    let ret = &input.sig.output;
+    let name = &input.sig.ident;
+    let body = &input.block;
+    let attrs = &input.attrs;
+    let vis = input.vis;
+
+    for attr in attrs {
+        if attr.path.is_ident("test") {
+            let msg = "second test attribute is supplied";
+            return syn::Error::new_spanned(&attr, msg)
+                .to_compile_error()
+                .into();
+        }
+    }
+
+    if input.sig.asyncness.is_none() {
+        let msg = "the async keyword is missing from the function declaration";
+        return syn::Error::new_spanned(&input.sig.fn_token, msg)
+            .to_compile_error()
+            .into();
+    } else if !input.sig.inputs.is_empty() {
+        let msg = "the test function cannot accept arguments";
+        return syn::Error::new_spanned(&input.sig.inputs, msg)
+            .to_compile_error()
+            .into();
+    }
+
+    let mut runtime = Runtime::Auto;
+
+    for arg in args {
+        if let syn::NestedMeta::Meta(syn::Meta::Path(path)) = arg {
+            let ident = path.get_ident();
+            if ident.is_none() {
+                let msg = "Must have specified ident";
+                return syn::Error::new_spanned(path, msg)
+                    .to_compile_error()
+                    .into();
+            }
+            match ident.unwrap().to_string().to_lowercase().as_str() {
+                "threaded_scheduler" => runtime = Runtime::Threaded,
+                "basic_scheduler" => runtime = Runtime::Basic,
+                name => {
+                    let msg = format!("Unknown attribute {} is specified; expected `basic_scheduler` or `threaded_scheduler`", name);
+                    return syn::Error::new_spanned(path, msg)
+                        .to_compile_error()
+                        .into();
+                }
+            }
+        }
+    }
+
+    let result = match runtime {
+        Runtime::Threaded => quote! {
+            #[test]
+            #(#attrs)*
+            #vis fn #name() #ret {
+                tokio_compat::runtime::Runtime::new().unwrap().block_on_std(async { #body })
+            }
+        },
+        Runtime::Basic | Runtime::Auto => quote! {
+            #[test]
+            #(#attrs)*
+            #vis fn #name() #ret {
+                tokio_compat::runtime::current_thread::Runtime::new().unwrap().block_on_std(async { #body })
+            }
+        },
+    };
+
+    result.into()
+}


### PR DESCRIPTION
I'm opening a "draft" PR for this, because there are definitely some issues to address,
but wanted to show a POC for this.

Having `tokio-compat` macros that are orthogonal to the `tokio` ones will make the transition story from 0.1 to 0.2 a little easier, I hope.

Unfortunately, these are, for the time being, mostly copy-pasted from [`tokio-macros`](https://github.com/tokio-rs/tokio/blob/3bff5a3ffe68c7bbf94fc91a58633f5a91f4266c/tokio-macros/src/lib.rs) (they have undergone some changes on latest `master`, but I'm sticking the version of the macros released with `tokio 0.2.6`). I tried anything I could think of to prevent this "ugly" duplication of code, but alas... couldn't find any reasonable method to do it. :(

Some questions I'd like to ask the maintainers of this create before taking this PR out of draft status:
- Is this even something you guys think should be part of the `tokio-compat` story?
- Should the file hierarchy of this repo be changed to a "workspace" style with multiple crates? Currently I just created a new crate a root-level dir, because of the (current) limitation whereas a proc macro crate can export *only* proc macros.
- Naming-themed bikeshedding: `tokio-compat-macros`? `tokio-macros-compat`?

Obviously this also needs a little documentation, but I wanted to get a general green-light before going down that path.

(Also - this is my first "real" contribution to the Rust ecosystem, would really love to be able to give some back to this amazing community.)