### PR TITLE
runtime: remove needless 'static bounds

### DIFF
--- a/src/runtime/current_thread/mod.rs
+++ b/src/runtime/current_thread/mod.rs
@@ -96,7 +96,7 @@ use std::future::Future;
 #[cfg_attr(docsrs, doc(cfg(feature = "rt-current-thread")))]
 pub fn block_on_all<F>(future: F) -> Result<F::Item, F::Error>
 where
-    F: Future01 + 'static,
+    F: Future01,
 {
     block_on_all_std(future.compat())
 }
@@ -109,7 +109,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "rt-current-thread")))]
 pub fn block_on_all_std<F>(future: F) -> F::Output
 where
-    F: Future + 'static,
+    F: Future,
 {
     let mut r = Runtime::new().expect("failed to start runtime on current thread");
     let v = r.block_on_std(future);

--- a/src/runtime/current_thread/runtime.rs
+++ b/src/runtime/current_thread/runtime.rs
@@ -307,7 +307,7 @@ impl Runtime {
     /// complete execution by calling `block_on` or `run`.
     pub fn block_on<F>(&mut self, f: F) -> Result<F::Item, F::Error>
     where
-        F: Future01 + 'static,
+        F: Future01,
     {
         self.block_on_std(f.compat())
     }
@@ -330,7 +330,7 @@ impl Runtime {
     /// complete execution by calling `block_on` or `run`.
     pub fn block_on_std<F>(&mut self, f: F) -> F::Output
     where
-        F: Future + 'static,
+        F: Future,
     {
         let handle = self.inner.handle().clone();
         let Runtime {

--- a/src/runtime/threadpool/mod.rs
+++ b/src/runtime/threadpool/mod.rs
@@ -112,7 +112,7 @@ struct Inner {
 #[cfg_attr(docsrs, doc(cfg(feature = "rt-full")))]
 pub fn run<F>(future: F)
 where
-    F: Future01<Item = (), Error = ()>,
+    F: Future01<Item = (), Error = ()> + Send + 'static,
 {
     run_std(future.compat().map(|_| ()))
 }
@@ -164,10 +164,10 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "rt-full")))]
 pub fn run_std<F>(future: F)
 where
-    F: Future<Output = ()>,
+    F: Future<Output = ()> + Send + 'static,
 {
     let mut runtime = Runtime::new().expect("failed to start new Runtime");
-    runtime.block_on_std(future);
+    runtime.spawn_std(future);
     runtime.shutdown_on_idle().wait().unwrap();
 }
 

--- a/src/runtime/threadpool/mod.rs
+++ b/src/runtime/threadpool/mod.rs
@@ -114,9 +114,7 @@ pub fn run<F>(future: F)
 where
     F: Future01<Item = (), Error = ()>,
 {
-    let runtime = Runtime::new().expect("failed to start new Runtime");
-    runtime.spawn(future);
-    runtime.shutdown_on_idle().wait().unwrap();
+    run_std(future.compat().map(|_| ()))
 }
 
 /// Start the Tokio runtime using the supplied `std::future` future to bootstrap

--- a/src/runtime/threadpool/mod.rs
+++ b/src/runtime/threadpool/mod.rs
@@ -112,7 +112,7 @@ struct Inner {
 #[cfg_attr(docsrs, doc(cfg(feature = "rt-full")))]
 pub fn run<F>(future: F)
 where
-    F: Future01<Item = (), Error = ()> + Send + 'static,
+    F: Future01<Item = (), Error = ()>,
 {
     let runtime = Runtime::new().expect("failed to start new Runtime");
     runtime.spawn(future);
@@ -166,7 +166,7 @@ where
 #[cfg_attr(docsrs, doc(cfg(feature = "rt-full")))]
 pub fn run_std<F>(future: F)
 where
-    F: Future<Output = ()> + Send + 'static,
+    F: Future<Output = ()>,
 {
     let mut runtime = Runtime::new().expect("failed to start new Runtime");
     runtime.block_on_std(future);


### PR DESCRIPTION
* current_thread: block_on futures needn't be static

The current_thread runtime's `block_on` and `block_on_std` functions
have `'static` bounds on the input future type. These are unnecessary,
since the inner tokio 0.2 runtime doesn't require these bounds, and they
aren't required by tokio 0.1, breaking API compatibility.

* threadpool: run futures needn't be static

Similarly, futures passed to the threadpool's `run` also don't need
`'static` bounds. This commit removes them.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>

