### PR TITLE
prepare to release version 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.1.3 (January 7, 2019)
+
+### Fixed
+
+- Removed unnecessary `'static` bounds on the `current_thread` runtime's
+  `block_on`/`block_on_std` functions that broke API compatibility with Tokio
+  0.1 (#17)
+
+### Added
+
+- Implementation of `futures` 0.1 `Executor` trait for `TaskExecutor`s (#18)
+
 # 0.1.2 (December 18, 2019)
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio-compat"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.2"
+version = "0.1.3"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio-compat/0.1.2/tokio-compat/"
+documentation = "https://docs.rs/tokio-compat/0.1.3/tokio-compat/"
 repository = "https://github.com/tokio-rs/tokio-compat"
 homepage = "https://tokio.rs"
 description = """

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Compatibility layers between `tokio` 0.2 and legacy versions.
 
 [crates-badge]: https://img.shields.io/crates/v/tokio-compat.svg
 [crates-url]: https://crates.io/crates/tokio-compat
-[docs-url]: https://docs.rs/tokio-compat/0.1.2/tokio-compat
+[docs-url]: https://docs.rs/tokio-compat/0.1.3/tokio-compat
 [docs-badge]: https://docs.rs/tokio-compat/badge.svg
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 //! - `rt-current-thread`: enables the `current_thread` compatibilty runtime
 //! - `rt-full`: enables the `current_thread` and threadpool compatibility
 //!   runtimes (enabled by default)
-#![doc(html_root_url = "https://docs.rs/tokio-compat/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/tokio-compat/0.1.3")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
### Fixed

- Removed unnecessary `'static` bounds on the `current_thread` runtime's
  `block_on`/`block_on_std` functions that broke API compatibility with
  Tokio 0.1 (#17)

### Added

- Implementation of `futures` 0.1 `Executor` trait for `TaskExecutor`s (#18)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>