### PR TITLE
threadpool: fix warnings

### DIFF
--- a/src/runtime/threadpool/builder.rs
+++ b/src/runtime/threadpool/builder.rs
@@ -88,6 +88,9 @@ impl Builder {
     /// # }
     /// ```
     pub fn core_threads(&mut self, val: usize) -> &mut Self {
+        // the deprecation warning states that this method will be replaced, but
+        // the method that will replace it doesn't exist yet...
+        #[allow(deprecated)]
         self.inner.num_threads(val);
         self
     }

--- a/src/runtime/threadpool/mod.rs
+++ b/src/runtime/threadpool/mod.rs
@@ -166,7 +166,7 @@ pub fn run_std<F>(future: F)
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    let mut runtime = Runtime::new().expect("failed to start new Runtime");
+    let runtime = Runtime::new().expect("failed to start new Runtime");
     runtime.spawn_std(future);
     runtime.shutdown_on_idle().wait().unwrap();
 }


### PR DESCRIPTION
This fixes two warnings in the threadpool compat runtime. 

Signed-off-by: Eliza Weisman <eliza@buoyant.io>