### PR TITLE
prepare to release 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.4 (January 8, 2019)
+
+### Fixed
+
+- Compiler warnings in the threadpool runtime (#21)
+
 # 0.1.3 (January 7, 2019)
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio-compat"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.3"
+version = "0.1.4"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio-compat/0.1.3/tokio-compat/"
+documentation = "https://docs.rs/tokio-compat/0.1.4/tokio-compat/"
 repository = "https://github.com/tokio-rs/tokio-compat"
 homepage = "https://tokio.rs"
 description = """

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Compatibility layers between `tokio` 0.2 and legacy versions.
 
 [crates-badge]: https://img.shields.io/crates/v/tokio-compat.svg
 [crates-url]: https://crates.io/crates/tokio-compat
-[docs-url]: https://docs.rs/tokio-compat/0.1.3/tokio-compat
+[docs-url]: https://docs.rs/tokio-compat/0.1.4/tokio-compat
 [docs-badge]: https://docs.rs/tokio-compat/badge.svg
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 //! - `rt-current-thread`: enables the `current_thread` compatibilty runtime
 //! - `rt-full`: enables the `current_thread` and threadpool compatibility
 //!   runtimes (enabled by default)
-#![doc(html_root_url = "https://docs.rs/tokio-compat/0.1.3")]
+#![doc(html_root_url = "https://docs.rs/tokio-compat/0.1.4")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
Fixed:

- Compiler warnings in the threadpool runtime (#21)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>