### PR TITLE
Add `Runtime::enter`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ tokio-current-thread-01 = { package = "tokio-current-thread", version = "0.1", o
 
 [dev-dependencies]
 tokio-01 = { package = "tokio", version = "0.1" }
+futures-03 = { package = "futures", version = "0.3" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,6 @@ tokio-current-thread-01 = { package = "tokio-current-thread", version = "0.1", o
 
 [dev-dependencies]
 tokio-01 = { package = "tokio", version = "0.1" }
-futures-03 = { package = "futures", version = "0.3" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/runtime/current_thread/runtime.rs
+++ b/src/runtime/current_thread/runtime.rs
@@ -427,6 +427,8 @@ impl Runtime {
         // Set the default tokio 0.1 reactor to the background compat reactor.
         let _reactor = reactor_01::set_default(compat.reactor());
         let _timer = timer_02::timer::set_default(compat.timer());
-        executor_01::with_default(&mut spawner, &mut enter, |_enter| inner.enter(f))
+        executor_01::with_default(&mut spawner, &mut enter, |_enter| {
+            Self::with_idle(idle, || inner.enter(f))
+        })
     }
 }

--- a/src/runtime/current_thread/runtime.rs
+++ b/src/runtime/current_thread/runtime.rs
@@ -409,4 +409,24 @@ impl Runtime {
             .try_with(|c| c.borrow().is_some())
             .unwrap_or(false)
     }
+
+    /// Enter the runtime context
+    pub fn enter<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        let handle = self.inner.handle().clone();
+        let Runtime {
+            ref inner,
+            ref compat,
+            ref idle,
+            ..
+        } = *self;
+        let mut spawner = compat::CompatSpawner::new(handle, &idle);
+        let mut enter = executor_01::enter().unwrap();
+        // Set the default tokio 0.1 reactor to the background compat reactor.
+        let _reactor = reactor_01::set_default(compat.reactor());
+        let _timer = timer_02::timer::set_default(compat.timer());
+        executor_01::with_default(&mut spawner, &mut enter, |_enter| inner.enter(f))
+    }
 }

--- a/src/runtime/threadpool/mod.rs
+++ b/src/runtime/threadpool/mod.rs
@@ -554,6 +554,20 @@ impl Runtime {
     fn inner_mut(&mut self) -> &mut Inner {
         self.inner.as_mut().unwrap()
     }
+
+    /// Enter the runtime context
+    pub fn enter<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        let spawner = self.spawner();
+        let inner = self.inner();
+        let compat = &inner.compat_bg;
+        let _timer = timer_02::timer::set_default(compat.timer());
+        let _reactor = reactor_01::set_default(compat.reactor());
+        let _executor = executor_01::set_default(spawner);
+        inner.runtime.enter(f)
+    }
 }
 
 impl Drop for Runtime {

--- a/tests/rt_current_thread.rs
+++ b/tests/rt_current_thread.rs
@@ -178,15 +178,14 @@ fn enter_can_spawn_01_futures() {
     use futures_01::future::IntoFuture;
     let future_ran = Arc::new(AtomicBool::new(false));
     let ran = future_ran.clone();
-    let rt = current_thread::Runtime::new().unwrap();
+    let mut rt = current_thread::Runtime::new().unwrap();
     rt.enter(|| {
-        let future = tokio_01::spawn(futures_01::future::lazy(move || {
+        tokio_01::spawn(futures_01::future::lazy(move || {
             future_ran.store(true, Ordering::SeqCst);
             Ok(())
-        }))
-        .into_future()
-        .compat();
-        futures_03::executor::block_on(future)
-    }).unwrap();
+        }));
+    });
+
+    rt.run();
     assert!(ran.load(Ordering::SeqCst));
 }

--- a/tests/rt_current_thread.rs
+++ b/tests/rt_current_thread.rs
@@ -175,7 +175,6 @@ fn enter_exposed() {
 
 #[test]
 fn enter_can_spawn_01_futures() {
-    use futures_01::future::IntoFuture;
     let future_ran = Arc::new(AtomicBool::new(false));
     let ran = future_ran.clone();
     let mut rt = current_thread::Runtime::new().unwrap();

--- a/tests/rt_threadpool.rs
+++ b/tests/rt_threadpool.rs
@@ -182,3 +182,29 @@ fn idle_after_block_on() {
     rt.shutdown_on_idle();
     assert!(ran.load(Ordering::SeqCst));
 }
+
+#[test]
+fn enter_exposed() {
+    let rt = runtime::Runtime::new().unwrap();
+    rt.enter(|| {
+        let _handle = tokio_02::runtime::Handle::current();
+    });
+}
+
+#[test]
+fn enter_can_spawn_01_futures() {
+    use futures_01::future::IntoFuture;
+    let future_ran = Arc::new(AtomicBool::new(false));
+    let ran = future_ran.clone();
+    let rt = runtime::Runtime::new().unwrap();
+    rt.enter(|| {
+        let future = tokio_01::spawn(futures_01::future::lazy(move || {
+            future_ran.store(true, Ordering::SeqCst);
+            Ok(())
+        }))
+        .into_future()
+        .compat();
+        futures_03::executor::block_on(future)
+    }).unwrap();
+    assert!(ran.load(Ordering::SeqCst));
+}

--- a/tests/rt_threadpool.rs
+++ b/tests/rt_threadpool.rs
@@ -196,15 +196,14 @@ fn enter_can_spawn_01_futures() {
     use futures_01::future::IntoFuture;
     let future_ran = Arc::new(AtomicBool::new(false));
     let ran = future_ran.clone();
-    let rt = runtime::Runtime::new().unwrap();
+    let mut rt = runtime::Runtime::new().unwrap();
     rt.enter(|| {
-        let future = tokio_01::spawn(futures_01::future::lazy(move || {
+        tokio_01::spawn(futures_01::future::lazy(move || {
             future_ran.store(true, Ordering::SeqCst);
             Ok(())
         }))
-        .into_future()
-        .compat();
-        futures_03::executor::block_on(future)
-    }).unwrap();
+    });
+
+    rt.shutdown_on_idle();
     assert!(ran.load(Ordering::SeqCst));
 }

--- a/tests/rt_threadpool.rs
+++ b/tests/rt_threadpool.rs
@@ -193,7 +193,6 @@ fn enter_exposed() {
 
 #[test]
 fn enter_can_spawn_01_futures() {
-    use futures_01::future::IntoFuture;
     let future_ran = Arc::new(AtomicBool::new(false));
     let ran = future_ran.clone();
     let mut rt = runtime::Runtime::new().unwrap();


### PR DESCRIPTION
Add a `Runtime::enter` function that allows the caller to enter the runtime context without calling `run`, `spawn`, or `block_on`. This mirrors the `enter` function from Tokio 0.2's runtime.

---

There were three approaches I saw to #24.

1. Expose the underlying tokio_02::Runtime
2. Expose a tokio_02::Handle
3. Expose an `enter` function. I opted for this one.

All three have the question of what to do with the idle tracker (I did nothing 😬). By implementing an `enter`, this also guarantees that everything is set up on the tokio_01 compatibility layer, I think.

This solves the problem in #24 that I need solved, using the multi-threaded runtime. I tested it on our app and it works perfectly.

However, I don't know enough about the current_thread runtime to get the same test to pass.