### PR TITLE
Fix possible fd leak with threaded runtime

### DIFF
--- a/src/runtime/threadpool/builder.rs
+++ b/src/runtime/threadpool/builder.rs
@@ -165,15 +165,15 @@ impl Builder {
             Arc::new(RwLock::new(None));
 
         // We need a weak ref here so that when we pass this into the
-        // `on_thread_start` closure its stored as a _weak_ ref and not
+        // `on_thread_start` closure it's stored as a _weak_ ref and not
         // a strong one. This is important because tokio 0.2's runtime
-        // should shutdown when the compat Runtime has been dropped. There
-        // can be a race condition where we hold onto an extra Arc which holds
-        // a runtime handle beyond the drop. This casuses the tokio runtime to
-        // not shutdown and leak fds.
+        // should shut down when the compat Runtime has been dropped. There
+        // can be a race condition where we hold onto an extra Arc, which holds
+        // a runtime handle beyond the drop. This causes the tokio 0.2 runtime to
+        // not shut down and leak fds.
         //
-        // Tokio's threaded_scheduler will spawn threads that each contain a arced
-        // ref to the `on_thread_start` fn. If the runtime shutsdown but there is still
+        // Tokio 0.2's threaded_scheduler will spawn threads that each contain an arced
+        // ref to the `on_thread_start` fn. If the runtime shuts down but there is still
         // access to a runtime handle the mio driver will not shutdown. To avoid this we
         // only want the `on_thread_start` to hold a weak ref and attempt to check async if
         // the runtime has been shutdown by upgrading the weak pointer.
@@ -186,8 +186,8 @@ impl Builder {
             .enable_all()
             .on_thread_start(move || {
                 // We need the threadpool's sender to set up the default tokio
-                // 0.1 executor. We also need to upgrade the weak pointer, if the
-                // pointer is no longer valid then the runtime has shutdown and the
+                // 0.1 executor. We also need to upgrade the weak pointer. If the
+                // pointer is no longer valid, then the runtime has shut down and the
                 // handle is no longer available.
                 //
                 // This upgrade will only fail if the compat runtime has been dropped.

--- a/src/runtime/threadpool/builder.rs
+++ b/src/runtime/threadpool/builder.rs
@@ -174,7 +174,7 @@ impl Builder {
         //
         // Tokio 0.2's threaded_scheduler will spawn threads that each contain an arced
         // ref to the `on_thread_start` fn. If the runtime shuts down but there is still
-        // access to a runtime handle the mio driver will not shutdown. To avoid this we
+        // access to a runtime handle, the mio driver will not shutdown. To avoid this we
         // only want the `on_thread_start` to hold a weak ref and attempt to check async if
         // the runtime has been shutdown by upgrading the weak pointer.
         let compat_sender2 = Arc::downgrade(&compat_sender);

--- a/src/runtime/threadpool/mod.rs
+++ b/src/runtime/threadpool/mod.rs
@@ -49,8 +49,8 @@ pub struct Runtime {
     idle: idle::Idle,
     idle_rx: idle::Rx,
 
-    // This should store the only long living strong ref to the handle
-    // and once Runtime is dropped it should also deallocate.
+    // This should store the only long-living strong ref to the handle,
+    // and once the Runtime is dropped, it should also be deallocated.
     compat_sender: Arc<RwLock<Option<CompatSpawner<tokio_02::runtime::Handle>>>>,
 }
 

--- a/src/runtime/threadpool/mod.rs
+++ b/src/runtime/threadpool/mod.rs
@@ -13,7 +13,12 @@ use super::{
 
 use futures_01::future::Future as Future01;
 use futures_util::{compat::Future01CompatExt, future::FutureExt};
-use std::{fmt, future::Future, io};
+use std::{
+    fmt,
+    future::Future,
+    io,
+    sync::{Arc, RwLock},
+};
 use tokio_02::{
     runtime::{self, Handle},
     task::JoinHandle,
@@ -43,6 +48,10 @@ pub struct Runtime {
     /// Idleness tracking.
     idle: idle::Idle,
     idle_rx: idle::Rx,
+
+    // This should store the only long living strong ref to the handle
+    // and once Runtime is dropped it should also deallocate.
+    compat_sender: Arc<RwLock<Option<CompatSpawner<tokio_02::runtime::Handle>>>>,
 }
 
 /// A future that resolves when the Tokio `Runtime` is shut down.


### PR DESCRIPTION
This PR introduces a fix where creating many runtimes in a loop will
cause an fd leak. This is because storing a strong arc within each
`on_thread_start` fn will cause the runtime handle to not be deallocated
when the `compat::Runtime` is dropped. To avoid this we only store a
weak pointer within the `on_thread_start` fn and attempt to upgrade it
to get the handle. Since, `on_thread_start` is generally always called
while the tokio runtime is not dropped the upgrade should not fail. This
then allows us to drop the runtime and deallocate the handle by storing
the only long lived strong arc within `compat::Runtime`.

I've verified this fixes our repro and doesn't leak fds on our
benchmarks where we orignally discovered this issue.

Closes #27

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>