### PR TITLE
Use doc(no_inline) on unnamed prelude exports

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,6 @@
 //! A prelude for `tokio` 0.1/0.2 compatibility.
 #[cfg(feature = "sink")]
+#[doc(no_inline)]
 pub use futures_util::compat::Sink01CompatExt as _;
+#[doc(no_inline)]
 pub use futures_util::compat::{Future01CompatExt as _, Stream01CompatExt as _};


### PR DESCRIPTION
refs: https://github.com/rust-lang/rust/issues/61592#issuecomment-499672626

before: 
<img width="669" alt="tokio-compat-doc-1" src="https://user-images.githubusercontent.com/43724913/79879794-20159680-842a-11ea-8a48-c5ce5792e152.png">

after:
<img width="669" alt="tokio-compat-doc-3" src="https://user-images.githubusercontent.com/43724913/79879817-27d53b00-842a-11ea-9db8-6059f873e672.png">

